### PR TITLE
Commented Out "No Internet" Alert

### DIFF
--- a/PotatoParty/PotatoParty/ContactsViewController.swift
+++ b/PotatoParty/PotatoParty/ContactsViewController.swift
@@ -552,7 +552,7 @@ extension ContactsViewController {
         
     }
     
-    func checkFirebaseConnection() {
+ /*   func checkFirebaseConnection() {
         let connectedRef = FIRDatabase.database().reference(withPath: ".info/connected")
         connectedRef.observe(.value, with: { snapshot in
             if let connected = snapshot.value as? Bool, !connected, self.firebaseStateChangeCounter > 0 {
@@ -564,7 +564,8 @@ extension ContactsViewController {
             self.firebaseStateChangeCounter += 1
         })
     }
-    
+ */
+
 }
 
 


### PR DESCRIPTION
Commented out "No internet connection" alert, which erroneously notified users they weren't connected to the internet. (Didn't want to fully delete it without review in case the function affects anyone else's functions/VCs.)